### PR TITLE
Heap based Priority Queue

### DIFF
--- a/src/header/CompleteTree.h
+++ b/src/header/CompleteTree.h
@@ -1,0 +1,71 @@
+/**
+ * @file   CompleteTree.h
+ * @brief  Assignment #7 - Heap Sort
+ *
+ * @author Ethan Slattery
+ * @date   3-MAR-2016
+ */
+#ifndef PROJECT_COMPLETETREE_H
+#define PROJECT_COMPLETETREE_H
+
+#include <vector>   // Underlying container for the class
+
+/**
+ * @brief A Complete binary tree class
+ * This class creates a complete binary tree, or a tree where every level has the
+ * maximum number of nodes possible, and the nodes in the last level fill from
+ * left to right.
+ */
+template <typename E>
+class CompleteTree {
+public:
+  // Constructor: Initialized the vector to a size of one, since we do not use index 0
+  CompleteTree() : V(1) {}
+
+  // Typedef for a position in the tree
+  typedef typename std::vector<E>::iterator Position;
+
+  /*** CONSTANT UTILITY METHODS ***/
+  // Returns TRUE if the tree is empty
+  bool empty() const { return size() == 0; }
+  // Returns the size of the tree
+  int size() const { return V.size()-1; }
+  // returns TRUE if the position has a LEFT child
+  bool hasLeft(const Position& p) const { return 2*idx(p) <= size(); }
+  // returns TRUE if the position has a RIGHT child
+  bool hasRight(const Position& p) const { return 2*idx(p)+1 <= size(); }
+  // returns TRUE if the position is ROOT
+  bool isRoot(const Position& p) const { return idx(p) == 1; }
+
+  /*** NON-CONSTANT UTILITY METHODS FOR THE TREE ***/
+  // Returns the root of the tree
+  Position root() { return pos(1); }
+  // Returns the last element in the tree
+  Position last() { return pos(size()); }
+  // Add an element to the end of the tree and RETURN ITS POSITION
+  Position addLast(const E& e) { V.push_back(e); return last(); }
+  // Remove an element from the end of the tree
+  void removeLast() { V.pop_back(); }
+  // Swaps the contents of two positions in the tree
+  void swap(const Position& p, const Position& q) { E e = *q; *q = *p; *p = e; }
+
+  /*** NON-CONSTANT UTILITY METHODS FOR NODES ***/
+  // Returns the left child of the position
+  Position left(const Position& p) { return pos(2*idx(p)); }
+  // Returns the right child of the position
+  Position right(const Position& p) { return pos(2*idx(p) + 1); }
+  // Returns the parent node of the current position
+  Position parent(const Position& p) { return pos(idx(p)/2); }
+
+protected:
+  /*** UTILITY METHODS ***/
+  // Maps an index in the vector to a position in the tree
+  Position pos(int i) { return V.begin()+i; }
+  // Maps a position in the tree to an index in the vector
+  int idx(const Position& p) const { return p - V.begin(); }
+
+private:
+  std::vector<E> V;   //< The vector to hold the tree contents
+};
+
+#endif //PROJECT_COMPLETETREE_H

--- a/src/header/HeapPriorityQueue.h
+++ b/src/header/HeapPriorityQueue.h
@@ -33,8 +33,6 @@ public:
   void push(const E &e);
   // Removes the minimum element from the queue
   void pop();
-  // Displays the heap as a tree-graph in the DOT language
-  void HeapOut(std::string title, std::ostream &oFile) { tree_.GraphTree(title, oFile); }
 
 private:
   CompleteTree<E> tree_;    //< The contents of the PQueue

--- a/src/header/HeapPriorityQueue.h
+++ b/src/header/HeapPriorityQueue.h
@@ -1,0 +1,106 @@
+/**
+ * @file  HeapPriorityQueue.h
+ * @brief Assignment #7 - Heap Sort
+ *
+ * @author Ethan 
+ * @date   06-Mar-2016
+ */
+#ifndef PROJECT_HEAPPRIORITYQUEUE_H
+#define PROJECT_HEAPPRIORITYQUEUE_H
+
+#include "CompleteTree.h"
+
+/**
+ * @brief A heap based priority queue
+ * This class implements a heap based priority queue, using a vector as the underlying
+ * structure. The data to be stored and the comparator is templated.
+ *   typename E - The data to store in the heap
+ *   typename C - The comparator to use while sorting the queue
+ */
+template <typename E, typename C>
+class HeapPriorityQueue {
+public:
+  /*** CONSTANT UTILITY METHODS ***/
+  // Returns the size of the queue
+  int size() const { return tree_.size(); }
+  // Returns TRUE if the queue is empty
+  bool empty() const { return tree_.size() == 0; }
+
+  /*** NON-CONSTANT UTILITY METHODS ***/
+  // Returns the min element in the queue
+  const E& top() { return *(tree_.root());}
+  // Inserts an element into the queue
+  void push(const E &e);
+  // Removes the minimum element from the queue
+  void pop();
+  // Displays the heap as a tree-graph in the DOT language
+  void HeapOut(std::string title, std::ostream &oFile) { tree_.GraphTree(title, oFile); }
+
+private:
+  CompleteTree<E> tree_;    //< The contents of the PQueue
+  C isLess_;                //< Comparitor for the tree contents
+
+  // Typedef the position in the tree for ease of use within the queue class
+  typedef typename CompleteTree<E>::Position Position;
+};
+
+#endif //PROJECT_HEAPPRIORITYQUEUE_H
+
+/**
+ *  This method adds the element e to the heap.
+ *  It then performs a bubble up to restore heap order.
+ *  @param e [IN] The element to add
+ */
+template <typename E, typename C>
+void HeapPriorityQueue<E,C>::push(const E &e) {
+  Position v = tree_.addLast(e);
+
+  while(!tree_.isRoot(v)) {
+    // Add e to the heap and get position variable
+    Position u = tree_.parent(v);
+
+    // If v is in order then done!
+    if(!isLess_(*v, *u)) break;
+
+    // Else swap with the parent
+    tree_.swap(v,u);
+    v = u;
+  } // END WHILE LOOP
+} // END INSERT METHOD
+
+/**
+ *  This method removes the next element from the queue.
+ *  It then restores heap order by bubbling down
+ */
+template <typename E, typename C>
+void HeapPriorityQueue<E,C>::pop() {
+  // If there is only one node left, remove it!
+  if(size() == 1) {
+    tree_.removeLast();
+  }
+  // If there is more than one node then swap last and root and bubble down
+  else {
+    // Swap the last element and the root, then remove the last element (the ex-root)
+    Position u = tree_.root();
+    tree_.swap(u, tree_.last());
+    tree_.removeLast();
+
+    // Bubble down
+    while(tree_.hasLeft(u)){
+      // grab the left child of u
+      Position v = tree_.left(u);
+
+      // if there is a right child and it is less than the left child, make it v
+      if(tree_.hasRight(u) && isLess_(*(tree_.right(u)), *v)){
+        v = tree_.right(u);
+      }
+
+      // if v (the lesser of any children) is less than u (our node) then swap them.
+      if(isLess_(*v, *u)) {
+        tree_.swap(u,v);
+        u = v;
+      }
+      else break; //else... WE ARE DONE
+    } // END OF BUBBLE DOWN WHILE LOOP
+  } // END ELSE
+} // END METHOD

--- a/src/header/HeapPriorityQueue.h
+++ b/src/header/HeapPriorityQueue.h
@@ -28,7 +28,7 @@ public:
 
   /*** NON-CONSTANT UTILITY METHODS ***/
   // Returns the min element in the queue
-  const E& top() { return *(tree_.root());}
+  E& top() { return *(tree_.root());}
   // Inserts an element into the queue
   void push(const E &e);
   // Removes the minimum element from the queue

--- a/src/src.pro
+++ b/src/src.pro
@@ -30,7 +30,10 @@ HEADERS  += header/mainwindow.h \
     header/entry.h \
     header/graph.h \
     header/priorityqueue.h \
-    header/shoppingcart.h
+    header/shoppingcart.h \
+    header/CompleteTree.h \
+    header/HeapPriorityQueue.h
+
 
 FORMS    += form/mainwindow.ui \
             form/shoppingcart.ui

--- a/test/HeapPQ_tests.h
+++ b/test/HeapPQ_tests.h
@@ -1,7 +1,6 @@
 #ifndef HEAPPQUEUE_TESTS
 #define HEAPPQUEUE_TESTS
 
-
 #include "testrunner.h"
 #include <QObject>
 #include <QString>
@@ -11,9 +10,9 @@
 
 class HeapPQ_tests : public QObject
 {
-    typedef HeapPriorityQueue<int, std::greater<int> >     intPQueue;
-    typedef HeapPriorityQueue<QString, std::greater<QString> > stringPQueue;
-    typedef HeapPriorityQueue<Stadium, std::greater<Stadium> > stadiumPQueue;
+    typedef HeapPriorityQueue<int, std::less<int> >     intPQueue;
+    typedef HeapPriorityQueue<QString, std::less<QString> > stringPQueue;
+    typedef HeapPriorityQueue<Stadium, std::less<Stadium> > stadiumPQueue;
  Q_OBJECT
 private slots:
     /*** SPECIAL TEST SETUP AND TEARDOWN METHODS ***/
@@ -22,9 +21,9 @@ private slots:
     // Called after the last test function was executed.
     //void cleanupTestCase();
     // Called before every test, if it fails then the NEXT test does not run
-    void init();
+    //void init();
     // Called after every test function
-    void cleanup();
+    //void cleanup();
 
     /*** TESTS FOR THE CLASS ***/
     void test_constructor(); // tests the creation of the tree

--- a/test/HeapPQ_tests.h
+++ b/test/HeapPQ_tests.h
@@ -53,8 +53,14 @@ void HeapPQ_tests::test_insert()
     int testExpe[]    = { -1, 0, 1, 1024, 65536 };
     const int AR_SIZE = 5;
 
+    //test size
+    Q_ASSERT(queue.size() == 0);
+
     // fill the queue
     for(int i=0; i<AR_SIZE; i++) { queue.push(testData[i]); }
+
+    // test the size
+    Q_ASSERT(queue.size() == 5);
 
     // run tests to make sure in proper order and they are all there
     for(int i=0; i<AR_SIZE; i++) {
@@ -62,6 +68,8 @@ void HeapPQ_tests::test_insert()
       queue.pop();
     }
 }
+
+
 
 /*** THIS ADDS THE TEST TO THE LIST OF CLASSES TO RUN ***/
 DECLARE_TEST(HeapPQ_tests)

--- a/test/HeapPQ_tests.h
+++ b/test/HeapPQ_tests.h
@@ -1,0 +1,70 @@
+#ifndef HEAPPQUEUE_TESTS
+#define HEAPPQUEUE_TESTS
+
+
+#include "testrunner.h"
+#include <QObject>
+#include <QString>
+#include <functional>
+#include "HeapPriorityQueue.h"
+#include "stadium.h"
+
+class HeapPQ_tests : public QObject
+{
+    typedef HeapPriorityQueue<int, std::greater<int> >     intPQueue;
+    typedef HeapPriorityQueue<QString, std::greater<QString> > stringPQueue;
+    typedef HeapPriorityQueue<Stadium, std::greater<Stadium> > stadiumPQueue;
+ Q_OBJECT
+private slots:
+    /*** SPECIAL TEST SETUP AND TEARDOWN METHODS ***/
+    // Called before the first test function is executed. If this fails no tests are run
+    //void initTestCase();
+    // Called after the last test function was executed.
+    //void cleanupTestCase();
+    // Called before every test, if it fails then the NEXT test does not run
+    void init();
+    // Called after every test function
+    void cleanup();
+
+    /*** TESTS FOR THE CLASS ***/
+    void test_constructor(); // tests the creation of the tree
+    void test_insert(); // tests to ensure all values are added and size is correct
+
+private:
+
+};
+
+// tree constructor test
+void HeapPQ_tests::test_constructor()
+{
+    intPQueue     queue1;
+    stringPQueue  queue2;
+    stadiumPQueue queue3;
+
+    Q_ASSERT(queue1.empty());
+    Q_ASSERT(queue2.empty());
+    Q_ASSERT(queue3.empty());
+}
+
+// testing the insert method
+void HeapPQ_tests::test_insert()
+{
+    intPQueue queue;
+    int testData[]    = { -1, 0, 65536, 1, 1024 };
+    int testExpe[]    = { -1, 0, 1, 1024, 65536 };
+    const int AR_SIZE = 5;
+
+    // fill the queue
+    for(int i=0; i<AR_SIZE; i++) { queue.push(testData[i]); }
+
+    // run tests to make sure in proper order and they are all there
+    for(int i=0; i<AR_SIZE; i++) {
+      QCOMPARE(queue.top(), testExpe[i]);
+      queue.pop();
+    }
+}
+
+/*** THIS ADDS THE TEST TO THE LIST OF CLASSES TO RUN ***/
+DECLARE_TEST(HeapPQ_tests)
+#endif // HEAPPQUEUE_TESTS
+

--- a/test/graphtests.h
+++ b/test/graphtests.h
@@ -32,6 +32,7 @@ private slots:
     void test_removeEdge1();    // Test the removal of an edge
     void test_AddStadium();     // Tests the basic creation of a graph of stadiums and adding a few stadiums
     void test_MSTPrim();        // Tests the basic prim MST algortihm with ass12 data
+    void test_MSTRealPrim();        // Tests the basic prim MST algortihm with ass12 data
     //void test_Dijkstra();
 
 
@@ -202,6 +203,38 @@ void GraphTests::test_MSTPrim(){
     stringGraph_->insertEdge("New York","Boston", 214);
 
     Graph<QString>::EdgeList output = stringGraph_->MSTPrim();
+
+    for(Graph<QString>::EdgeItr i = output.begin(); i != output.end(); i++) {
+        qDebug() << i->print() << i->weight();
+    }
+}
+
+void GraphTests::test_MSTRealPrim(){
+    stringGraph_->insertEdge("Seattle","Chicago", 2097);
+    stringGraph_->insertEdge("Seattle","Denver", 1331);
+    stringGraph_->insertEdge("Seattle","San Francisco", 807);
+    stringGraph_->insertEdge("San Francisco","Los Angeles", 381);
+    stringGraph_->insertEdge("San Francisco","Denver", 1267);
+    stringGraph_->insertEdge("Los Angeles","Denver", 1015);
+    stringGraph_->insertEdge("Los Angeles","Kansas City", 1663);
+    stringGraph_->insertEdge("Los Angeles","Dallas", 1435);
+    stringGraph_->insertEdge("Denver","Chicago", 1003);
+    stringGraph_->insertEdge("Denver","Kansas City", 599);
+    stringGraph_->insertEdge("Chicago","Kansas City", 533);
+    stringGraph_->insertEdge("Chicago","Boston", 983);
+    stringGraph_->insertEdge("Chicago","New York", 787);
+    stringGraph_->insertEdge("Kansas City","Dallas", 496);
+    stringGraph_->insertEdge("Kansas City","New York", 1260);
+    stringGraph_->insertEdge("Kansas City","Atlanta", 864);
+    stringGraph_->insertEdge("Dallas","Houston", 239);
+    stringGraph_->insertEdge("Dallas","Atlanta", 781);
+    stringGraph_->insertEdge("Houston","Atlanta", 810);
+    stringGraph_->insertEdge("Houston","Miami", 1187);
+    stringGraph_->insertEdge("Atlanta","Miami", 661);
+    stringGraph_->insertEdge("Atlanta","New York", 888);
+    stringGraph_->insertEdge("New York","Boston", 214);
+
+    Graph<QString>::EdgeList output = stringGraph_->MSTRealPrim();
 
     for(Graph<QString>::EdgeItr i = output.begin(); i != output.end(); i++) {
         qDebug() << i->print() << i->weight();

--- a/test/test.pro
+++ b/test/test.pro
@@ -22,4 +22,5 @@ LIBS += -L../src -l$${APP_NAME}
 HEADERS += \
     testrunner.h \
     graphtests.h \
-    SkipListTests.h
+    SkipListTests.h \
+    HeapPQ_tests.h


### PR DESCRIPTION
This branch created a heap-based priority queue using a comparator for use in MST and Dijkstra. I also re-implemented PRIM to use the PQueue instead of the original way that just sorted a list. Both versions still exists though.
